### PR TITLE
feat(operator): add new budget column

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -41,6 +41,7 @@ type ShowWarehouseResult struct {
 	Failed          int
 	Suspended       int
 	Uuid            string
+	Budget		string
 }
 
 func OperateWAS(sfConfig *sf.Config, appConfig *arguments.WasArguments) {
@@ -90,6 +91,7 @@ func OperateWAS(sfConfig *sf.Config, appConfig *arguments.WasArguments) {
 				&rowResult.Failed,
 				&rowResult.Suspended,
 				&rowResult.Uuid,
+				&rowResult.Budget,
 			); err != nil {
 				log.Fatalf("Error at scanning result %v", err)
 			}


### PR DESCRIPTION
- [snowflake end](https://docs.snowflake.com/en/sql-reference/sql/show-warehouses#output) has changed to return 26 columns instead of the 25
- error from WAS `2023/10/02 04:43:34 Error at scanning result sql: expected 26 destination arguments in Scan, not 25`